### PR TITLE
Adapt p5.Speech to align with p5.js styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var voice = new p5.Speech(); // speech synthesis object
 voice.speak('hi there'); // say something
 ```
 
-##Simple Example (Recognition)
+## Simple Example (Recognition)
 
 ```javascript
 var speechRec = new p5.SpeechRec(gotSpeech); // speech recognition object (will prompt for mic access)

--- a/README.md
+++ b/README.md
@@ -9,19 +9,20 @@ This is a simple p5 extension to provide Web Speech (Synthesis and Recognition) 
 
 Speech recognition requires launching from a server (e.g. a python simpleserver on a local machine).
 
-##Simple Example (Synthesis)
-```
-var foo = new P5.Speech(); // speech synthesis object
-foo.speak('hi there'); // say something
-```
-##Simple Example (Recognition)
-```
-var foo = new P5.SpeechRec(); // speech recognition object (will prompt for mic access)
-foo.onResult = showResult; // bind callback function to trigger when speech is recognized
-foo.start(); // start listening
+## Simple Example (Synthesis)
 
-function showResult()
-{
-  console.log(foo.resultString); // log the result
+```javascript
+var voice = new p5.Speech(); // speech synthesis object
+voice.speak('hi there'); // say something
+```
+
+##Simple Example (Recognition)
+
+```javascript
+var speechRec = new p5.SpeechRec(gotSpeech); // speech recognition object (will prompt for mic access)
+speechRec.start(); // start listening
+
+function gotSpeech(speech) {
+  console.log(speech.text); // log the result
 }
 ```

--- a/examples/04simplerecognition.html
+++ b/examples/04simplerecognition.html
@@ -27,13 +27,11 @@
 		// why draw when you can talk?
 	}
 
-	function showResult()
+	function showResult(result)
 	{
-		if(myRec.resultValue==true) {
-			background(192, 255, 192);
-			text(myRec.resultString, width/2, height/2);
-			console.log(myRec.resultString);
-		}
+		background(192, 255, 192);
+		text(result.text, width/2, height/2);
+		console.log(result.text);
 	}
 
 </script>

--- a/examples/05continuousrecognition.html
+++ b/examples/05continuousrecognition.html
@@ -43,11 +43,11 @@
 		if(y>height) y = 0;
 	}
 
-	function parseResult()
+	function parseResult(result)
 	{
 		// recognition system will often append words into phrases.
 		// so hack here is to only use the last word:
-		var mostrecentword = myRec.resultString.split(' ').pop();
+		var mostrecentword = result.text.split(' ').pop();
 		if(mostrecentword.indexOf("left")!==-1) { dx=-1;dy=0; }
 		else if(mostrecentword.indexOf("right")!==-1) { dx=1;dy=0; }
 		else if(mostrecentword.indexOf("up")!==-1) { dx=0;dy=-1; }

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -36,7 +36,7 @@
    * @class p5.Speech
    * @constructor
    */
-  p5.Speech = function(_dv) {
+  p5.Speech = function(_callback, _dv) {
 
     //
     // speech synthesizers consist of a single synthesis engine
@@ -70,9 +70,15 @@
 
     this.voices = []; // array of available voices (dependent on browser/OS)
 
-    // first parameter of constructor is an initial voice selector
+    // checkig parameters of constructor is an initial voice selector
     this.initvoice;
-    if(_dv !== undefined) this.initvoice=_dv;
+
+    if(_callback !== undefined) {
+      this.onLoad = _callback;
+    }
+    if(_dv !== undefined) {
+      this.initvoice=_dv;
+    }
 
     var that = this; // some bullshit
 

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -100,7 +100,6 @@
 
         // fire custom onLoad() callback, if it exists:
         if(that.onLoad!=undefined) {
-          console.log('go!');
           that.onLoad();
         }
 
@@ -131,12 +130,20 @@
 
 
   // Setting callbacks with functions instead
-  p5.Speech.prototype.speechStart = function(callback) {
+  p5.Speech.prototype.started = function(callback) {
     this.onStart = callback;
   }
 
-  p5.Speech.prototype.speechEnd = function(callback) {
+  p5.Speech.prototype.ended = function(callback) {
     this.onEnd = callback;
+  }
+
+  p5.Speech.prototype.paused = function(callback) {
+    this.onPause = callback;
+  }
+
+  p5.Speech.prototype.resumed = function(callback) {
+    this.onResume = callback;
   }
 
   // listVoices() - dump voice names to javascript console:

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -11,7 +11,7 @@
  *  ABILITY Lab / Brooklyn Experimental Media Center
  *  New York University
  *  The MIT License (MIT).
- *  
+ *
  *  https://github.com/IDMNYU/p5.js-speech
  *
  *  Web Speech API: https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html
@@ -44,7 +44,7 @@
     // objects, which can be cached and re-used for, e.g.
     // auditory UI.
     //
-    // this implementation assumes a monolithic (one synth, 
+    // this implementation assumes a monolithic (one synth,
     // one phrase at a time) system.
     //
 
@@ -56,9 +56,9 @@
 
     this.isLoaded = 0; // do we have voices yet?
 
-    // do we queue new utterances upon firing speak() 
+    // do we queue new utterances upon firing speak()
     // or interrupt what's speaking:
-    this.interrupt = false; 
+    this.interrupt = false;
 
     // callback properties to be filled in within the p5 sketch
     // if the author needs custom callbacks:
@@ -79,14 +79,13 @@
     // onvoiceschanged() fires automatically when the synthesizer
     // is configured and has its voices loaded.  you don't need
     // to wait for this if you're okay with the default voice.
-    // 
+    //
     // we use this function to load the voice array and bind our
     // custom callback functions.
     window.speechSynthesis.onvoiceschanged = function() {
       if(that.isLoaded==0) { // run only once
         that.voices = window.speechSynthesis.getVoices();
         that.isLoaded = 1; // we're ready
-        console.log("p5.Speech: voices loaded!");
 
         if(that.initvoice!=undefined) {
           that.setVoice(that.initvoice); // set a custom initial voice
@@ -94,7 +93,10 @@
         }
 
         // fire custom onLoad() callback, if it exists:
-        if(that.onLoad!=undefined) that.onLoad();
+        if(that.onLoad!=undefined) {
+          console.log('go!');
+          that.onLoad();
+        }
 
         //
         // bind other custom callbacks:
@@ -102,25 +104,34 @@
 
         that.utterance.onstart = function(e) {
           //console.log("STARTED");
-          if(that.onStart!=undefined) that.onStart(e);        
+          if(that.onStart!=undefined) that.onStart(e);
         };
         that.utterance.onpause = function(e) {
           //console.log("PAUSED");
-          if(that.onPause!=undefined) that.onPause(e);        
+          if(that.onPause!=undefined) that.onPause(e);
         };
         that.utterance.onresume = function(e) {
           //console.log("RESUMED");
-          if(that.onResume!=undefined) that.onResume(e);        
+          if(that.onResume!=undefined) that.onResume(e);
         };
         that.utterance.onend = function(e) {
           //console.log("ENDED");
-          if(that.onEnd!=undefined) that.onEnd(e);        
+          if(that.onEnd!=undefined) that.onEnd(e);
         };
       }
     };
 
   };     // end p5.Speech constructor
 
+
+  // Setting callbacks with functions instead
+  p5.Speech.prototype.speechStart = function(callback) {
+    this.onStart = callback;
+  }
+
+  p5.Speech.prototype.speechEnd = function(callback) {
+    this.onEnd = callback;
+  }
 
   // listVoices() - dump voice names to javascript console:
   p5.Speech.prototype.listVoices = function() {
@@ -211,7 +222,7 @@
   p5.SpeechRec = function(_lang) {
 
     //
-    // speech recognition consists of a recognizer object per 
+    // speech recognition consists of a recognizer object per
     // window instance that returns a JSON object containing
     // recognition.  this JSON object grows when the synthesizer
     // is in 'continuous' mode, with new recognized phrases
@@ -248,7 +259,7 @@
 
     // continous mode means the object keeps recognizing speech,
     // appending new tokens to the internal JSON.
-    this.continuous = false; 
+    this.continuous = false;
     // interimResults means the object will report (i.e. fire its
     // onresult() callback) more frequently, rather than at pauses
     // in microphone input.  this gets you quicker, but less accurate,
@@ -258,41 +269,41 @@
     // result data:
 
     // resultJSON:
-    // this is a full JSON returned by onresult().  it consists of a 
+    // this is a full JSON returned by onresult().  it consists of a
     // SpeechRecognitionEvent object, which contains a (wait for it)
     // SpeechRecognitionResultList.  this is an array.  in continuous
-    // mode, it will be appended to, not cleared.  each element is a 
+    // mode, it will be appended to, not cleared.  each element is a
     // SpeechRecognition result, which contains a (groan)
     // SpeechRecognitionAlternative, containing a 'transcript' property.
     // the 'transcript' is the recognized phrase.  have fun.
-    this.resultJSON; 
+    this.resultJSON;
     // resultValue:
-    // validation flag which indicates whether the recognizer succeeded.  
+    // validation flag which indicates whether the recognizer succeeded.
     // this is *not* a metric of speech clarity, but rather whether the
     // speech recognition system successfully connected to and received
     // a response from the server.  you can construct an if() around this
     // if you're feeling worried.
-    this.resultValue; 
+    this.resultValue;
     // resultValue:
     // the 'transcript' of the most recently recognized speech as a simple
     // string.  this will be blown out and replaced at every firing of the
     // onresult() callback.
-    this.resultString; 
+    this.resultString;
     // resultConfidence:
     // the 'confidence' (0-1) of the most recently recognized speech, e.g.
     // that it reflects what was actually spoken.  you can use this to filter
     // out potentially bogus recognition tokens.
-    this.resultConfidence; 
+    this.resultConfidence;
 
     var that = this; // some bullshit
 
     // onresult() fires automatically when the recognition engine
     // detects speech, or times out trying.
-    // 
+    //
     // it fills up a JSON array internal to the webkitSpeechRecognition
-    // object.  we reference it over in our struct here, and also copy 
+    // object.  we reference it over in our struct here, and also copy
     // out the most recently detected phrase and confidence value.
-    this.rec.onresult = function(e) { 
+    this.rec.onresult = function(e) {
       that.resultJSON = e; // full JSON of callback event
       that.resultValue = e.returnValue; // was successful?
       // store latest result in top-level object struct
@@ -306,7 +317,7 @@
     this.rec.onstart = function(e) {
       if(that.onStart!=undefined) that.onStart(e);
     };
-    // fires on a client-side error (server-side errors are expressed 
+    // fires on a client-side error (server-side errors are expressed
     // by the resultValue in the JSON coming back as 'false').
     this.rec.onerror = function(e) {
       if(that.onError!=undefined) that.onError(e);
@@ -318,11 +329,11 @@
 
   }; // end p5.SpeechRec constructor
 
-  // start the speech recognition engine.  this will prompt a 
-  // security dialog in the browser asking for permission to 
+  // start the speech recognition engine.  this will prompt a
+  // security dialog in the browser asking for permission to
   // use the microphone.  this permission will persist throughout
   // this one 'start' cycle.  if you need to recognize speech more
-  // than once, use continuous mode rather than firing start() 
+  // than once, use continuous mode rather than firing start()
   // multiple times in a single script.
   p5.SpeechRec.prototype.start = function() {
     if('webkitSpeechRecognition' in window) {
@@ -343,6 +354,3 @@ todo:
 */
 
 // EOF
-
-
-

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -80,7 +80,7 @@
       this.initvoice=_dv;
     }
 
-    var that = this; // some bullshit
+    var that = this;
 
     // onvoiceschanged() fires automatically when the synthesizer
     // is configured and has its voices loaded.  you don't need
@@ -98,10 +98,6 @@
           console.log("p5.Speech: initial voice: " + that.initvoice);
         }
 
-        // fire custom onLoad() callback, if it exists:
-        if(that.onLoad!=undefined) {
-          that.onLoad();
-        }
 
         //
         // bind other custom callbacks:
@@ -123,6 +119,11 @@
           //console.log("ENDED");
           if(that.onEnd!=undefined) that.onEnd(e);
         };
+
+        // fire custom onLoad() callback, if it exists:
+        if(that.onLoad!=undefined) {
+          that.onLoad();
+        }
       }
     };
 
@@ -286,6 +287,7 @@
     // result data:
 
     // resultJSON:
+    // DEPRECATED - please use the result passed to the callback function.
     // this is a full JSON returned by onresult().  it consists of a
     // SpeechRecognitionEvent object, which contains a (wait for it)
     // SpeechRecognitionResultList.  this is an array.  in continuous
@@ -295,6 +297,7 @@
     // the 'transcript' is the recognized phrase.  have fun.
     this.resultJSON;
     // resultValue:
+    // DEPRECATED - please use the result passed to the callback function.
     // validation flag which indicates whether the recognizer succeeded.
     // this is *not* a metric of speech clarity, but rather whether the
     // speech recognition system successfully connected to and received
@@ -302,17 +305,19 @@
     // if you're feeling worried.
     this.resultValue;
     // resultValue:
+    // DEPRECATED - please use the result passed to the callback function.
     // the 'transcript' of the most recently recognized speech as a simple
     // string.  this will be blown out and replaced at every firing of the
     // onresult() callback.
     this.resultString;
     // resultConfidence:
+    // DEPRECATED - please use the result passed to the callback function.
     // the 'confidence' (0-1) of the most recently recognized speech, e.g.
     // that it reflects what was actually spoken.  you can use this to filter
     // out potentially bogus recognition tokens.
     this.resultConfidence;
 
-    var that = this; // some bullshit
+    var that = this;
 
     // onresult() fires automatically when the recognition engine
     // detects speech, or times out trying.
@@ -322,11 +327,11 @@
     // out the most recently detected phrase and confidence value.
     this.rec.onresult = function(e) {
       var result = {};
-      result.data = e; // full JSON of callback event
-      result.success = e.returnValue; // was successful?
+      result.data = this.resultJSON = e; // full JSON of callback event
+      result.success = this.resultValue = e.returnValue; // was successful?
       // store latest result in top-level object struct
-      result.text = e.results[e.results.length-1][0].transcript.trim();
-      result.confidence = e.results[e.results.length-1][0].confidence;
+      result.text = this.resultString = e.results[e.results.length-1][0].transcript.trim();
+      result.confidence = this.resultConfidence = e.results[e.results.length-1][0].confidence;
       if(that.onResult!=undefined) that.onResult(result);
     };
 

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -232,7 +232,7 @@
    * @class p5.SpeechRec
    * @constructor
    */
-  p5.SpeechRec = function(_lang) {
+  p5.SpeechRec = function(_callback, _lang) {
 
     //
     // speech recognition consists of a recognizer object per
@@ -255,15 +255,19 @@
       console.log("p5.SpeechRec: webkitSpeechRecognition not supported in this browser.");
     }
 
+    // This callback is somewhat required so add in here
+    this.onResult = _callback;
+
+
     // first parameter is language model (defaults to empty=U.S. English)
     // no list of valid models in API, but it must use BCP-47.
     // here's some hints:
     // http://stackoverflow.com/questions/14257598/what-are-language-codes-for-voice-recognition-languages-in-chromes-implementati
     if(_lang !== undefined) this.rec.lang=_lang;
 
+
     // callback properties to be filled in within the p5 sketch
     // if the author needs custom callbacks:
-    this.onResult; // fires when something has been recognized
     this.onStart; // fires when the recognition system is started...
     this.onError; // ...has a problem (e.g. the mic is shut off)...
     this.onEnd; // ...and ends (in non-continuous mode).
@@ -317,12 +321,13 @@
     // object.  we reference it over in our struct here, and also copy
     // out the most recently detected phrase and confidence value.
     this.rec.onresult = function(e) {
-      that.resultJSON = e; // full JSON of callback event
-      that.resultValue = e.returnValue; // was successful?
+      var result = {};
+      result.data = e; // full JSON of callback event
+      result.success = e.returnValue; // was successful?
       // store latest result in top-level object struct
-      that.resultString = e.results[e.results.length-1][0].transcript.trim();
-      that.resultConfidence = e.results[e.results.length-1][0].confidence;
-      if(that.onResult!=undefined) that.onResult();
+      result.text = e.results[e.results.length-1][0].transcript.trim();
+      result.confidence = e.results[e.results.length-1][0].confidence;
+      if(that.onResult!=undefined) that.onResult(result);
     };
 
     // fires when the recognition system starts (i.e. when you 'allow'


### PR DESCRIPTION
Hi @rev3rend! I am planning to do some tutorials around p5.Speech for my A2Z class and YouTube channel. This pull request suggests some syntax / style changes to make the library a bit more like other p5 libraries. For example, callbacks are passed through a function rather than assigned via `=` and some other small things have been changed.

What do you think about this?

Big thanks to @meiamsome who helped me with some of this work. In theory I'm going to do this video tutorial tomorrow (Friday, Oct 13), sorry for the last minute notice!