### PR TITLE
Replace recognizer properties with parameters

### DIFF
--- a/examples/05continuousrecognition.html
+++ b/examples/05continuousrecognition.html
@@ -28,8 +28,10 @@
 
 		myRec.onResult = parseResult; // recognition callback
 		
-		// start with do continuous recognition and allow partial recognition (faster, less accurate)
-		myRec.start(true, true); // start engine
+		// start with continuous recognition and allow partial recognition (faster, less accurate)
+		var continuous = true;
+		var interimResults = true;
+		myRec.start(continuous, interimResults); // start engine
 	}
 
 	function draw()

--- a/examples/05continuousrecognition.html
+++ b/examples/05continuousrecognition.html
@@ -6,8 +6,6 @@
 	<script>
 
 	var myRec = new p5.SpeechRec(); // new P5.SpeechRec object
-	myRec.continuous = true; // do continuous recognition
-	myRec.interimResults = true; // allow partial recognition (faster, less accurate)
 
 	var x, y;
 	var dx, dy;
@@ -29,7 +27,9 @@
 		text("draw: up, down, left, right, clear", 20, 20);
 
 		myRec.onResult = parseResult; // recognition callback
-		myRec.start(); // start engine
+		
+		// start with do continuous recognition and allow partial recognition (faster, less accurate)
+		myRec.start(true, true); // start engine
 	}
 
 	function draw()

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -273,17 +273,6 @@
     this.onError; // ...has a problem (e.g. the mic is shut off)...
     this.onEnd; // ...and ends (in non-continuous mode).
 
-    // recognizer properties:
-
-    // continous mode means the object keeps recognizing speech,
-    // appending new tokens to the internal JSON.
-    this.continuous = false;
-    // interimResults means the object will report (i.e. fire its
-    // onresult() callback) more frequently, rather than at pauses
-    // in microphone input.  this gets you quicker, but less accurate,
-    // results.
-    this.interimResults = false;
-
     // result data:
 
     // resultJSON:
@@ -358,10 +347,17 @@
   // this one 'start' cycle.  if you need to recognize speech more
   // than once, use continuous mode rather than firing start()
   // multiple times in a single script.
-  p5.SpeechRec.prototype.start = function() {
+  //
+  // continous mode means the object keeps recognizing speech,
+  // appending new tokens to the internal JSON.
+  //
+  // interimResults means the object will report (i.e. fire its
+  // onresult() callback) more frequently, rather than at pauses
+  // in microphone input.  this gets you quicker, but less accurate,
+  p5.SpeechRec.prototype.start = function(continuous, interimResults) {
     if('webkitSpeechRecognition' in window) {
-      this.rec.continuous = this.continuous;
-      this.rec.interimResults = this.interimResults;
+      this.rec.continuous = continuous !== false; // continous defaults to true
+      this.rec.interimResults = interimResults === false; // interimResults defaults to false
       this.rec.start();
     }
   };


### PR DESCRIPTION
@shiffman suggested replacing the parameters with arguments to start in todays live stream.
I'm using the same default parameters as him, but what's correct is debatable.