### PR TITLE
Formatting and some basic SpeechRec methods

### DIFF
--- a/examples/01simple.html
+++ b/examples/01simple.html
@@ -39,7 +39,7 @@
 
 	function doList()
 	{
-		myVoice.listVoices(); // debug printer for voice options
+		myVoice.logVoices(); // debug printer for voice options
 	}
 
 	function keyPressed()

--- a/examples/05continuousrecognition.html
+++ b/examples/05continuousrecognition.html
@@ -6,8 +6,8 @@
 	<script>
 
 	var myRec = new p5.SpeechRec(); // new P5.SpeechRec object
-	myRec.continuous = true; // do continuous recognition
-	myRec.interimResults = true; // allow partial recognition (faster, less accurate)
+	var continuous = true; // do continuous recognition
+	var interimResults = true; // allow partial recognition (faster, less accurate)
 
 	var x, y;
 	var dx, dy;
@@ -29,7 +29,7 @@
 		text("draw: up, down, left, right, clear", 20, 20);
 
 		myRec.onResult = parseResult; // recognition callback
-		myRec.start(); // start engine
+		myRec.start(continuous, interimResults); // start engine
 	}
 
 	function draw()

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -357,8 +357,8 @@
   // multiple times in a single script.
   p5.SpeechRec.prototype.start = function(_continuous, _interimResults) {
     if('webkitSpeechRecognition' in window) {
-      this.rec.continuous = this.continuous = _continuous === undefined ? this.continuous : _continuous;
-      this.rec.interimResults = this.interimResults = _interimResults === undefined ? this.interimResults : _interimResults;
+      this.rec.continuous = this.continuous = _continuous === true;
+      this.rec.interimResults = this.interimResults = _interimResults === true;
       this.rec.start();
     }
   };

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -54,7 +54,7 @@
     // make an utterance to use with this synthesizer:
     this.utterance = new SpeechSynthesisUtterance();
 
-    this.isLoaded = 0; // do we have voices yet?
+    this.isLoaded = false; // do we have voices yet?
 
     // do we queue new utterances upon firing speak()
     // or interrupt what's speaking:
@@ -77,7 +77,7 @@
       this.onLoad = _callback;
     }
     if(_dv !== undefined) {
-      this.initvoice=_dv;
+      this.initvoice = _dv;
     }
 
     var that = this;
@@ -89,13 +89,12 @@
     // we use this function to load the voice array and bind our
     // custom callback functions.
     window.speechSynthesis.onvoiceschanged = function() {
-      if(that.isLoaded==0) { // run only once
+      if(that.isLoaded == false) { // run only once
         that.voices = window.speechSynthesis.getVoices();
-        that.isLoaded = 1; // we're ready
+        that.isLoaded = true; // we're ready
 
-        if(that.initvoice!=undefined) {
+        if(that.initvoice !== undefined) {
           that.setVoice(that.initvoice); // set a custom initial voice
-          console.log("p5.Speech: initial voice: " + that.initvoice);
         }
 
 
@@ -105,23 +104,23 @@
 
         that.utterance.onstart = function(e) {
           //console.log("STARTED");
-          if(that.onStart!=undefined) that.onStart(e);
+          if(that.onStart !== undefined) that.onStart(e);
         };
         that.utterance.onpause = function(e) {
           //console.log("PAUSED");
-          if(that.onPause!=undefined) that.onPause(e);
+          if(that.onPause !== undefined) that.onPause(e);
         };
         that.utterance.onresume = function(e) {
           //console.log("RESUMED");
-          if(that.onResume!=undefined) that.onResume(e);
+          if(that.onResume !== undefined) that.onResume(e);
         };
         that.utterance.onend = function(e) {
           //console.log("ENDED");
-          if(that.onEnd!=undefined) that.onEnd(e);
+          if(that.onEnd !== undefined) that.onEnd(e);
         };
 
         // fire custom onLoad() callback, if it exists:
-        if(that.onLoad!=undefined) {
+        if(that.onLoad !== undefined) {
           that.onLoad();
         }
       }
@@ -147,17 +146,14 @@
     this.onResume = callback;
   }
 
-  // listVoices() - dump voice names to javascript console:
-  p5.Speech.prototype.listVoices = function() {
-    if(this.isLoaded)
-    {
-      for(var i = 0;i<this.voices.length;i++)
-      {
+  // logVoices() - dump voice names to javascript console:
+  p5.Speech.prototype.logVoices = function() {
+    if(this.isLoaded) {
+      for(var i = 0; i < this.voices.length; i++) {
         console.log(this.voices[i].name);
       }
     }
-    else
-    {
+    else {
     	console.log("p5.Speech: voices not loaded yet!")
     }
   };
@@ -166,8 +162,8 @@
   // (using voices found in the voices[] array), or by index.
   p5.Speech.prototype.setVoice = function(_v) {
     // type check so you can set by label or by index:
-    if(typeof(_v)=='string') this.utterance.voice = this.voices.filter(function(v) { return v.name == _v; })[0];
-    else if(typeof(_v)=='number') this.utterance.voice = this.voices[Math.min(Math.max(_v,0),this.voices.length-1)];
+    if(typeof _v === 'string') this.utterance.voice = this.voices.find(function(v) { return v.name === _v; });
+    else if(typeof _v === 'number') this.utterance.voice = this.voices[Math.min(Math.max(_v,0), this.voices.length-1)];
   };
 
   // volume of voice. API range 0.0-1.0.
@@ -182,7 +178,7 @@
   };
 
   // pitch of voice.  not all voices support this feature.
-  // API range >0.0-2.0.  voice will crash out of bounds.
+  // API range >0.01-2.0.  voice will crash out of bounds.
   p5.Speech.prototype.setPitch = function(_v) {
     this.utterance.pitch = Math.min(Math.max(_v, 0.01), 2.0);
   };
@@ -190,7 +186,7 @@
   // sets the language of the voice.
   p5.Speech.prototype.setLang = function(_lang) {
     this.utterance.lang = _lang;
-}
+  };
 
   // speak a phrase through the current synthesizer:
   p5.Speech.prototype.speak = function(_phrase) {
@@ -252,7 +248,7 @@
       this.rec = new webkitSpeechRecognition();
     }
     else {
-      this.rec = new Object();
+      this.rec = null;
       console.log("p5.SpeechRec: webkitSpeechRecognition not supported in this browser.");
     }
 
@@ -264,7 +260,7 @@
     // no list of valid models in API, but it must use BCP-47.
     // here's some hints:
     // http://stackoverflow.com/questions/14257598/what-are-language-codes-for-voice-recognition-languages-in-chromes-implementati
-    if(_lang !== undefined) this.rec.lang=_lang;
+    if(_lang !== undefined) this.setLang(_lang);
 
 
     // callback properties to be filled in within the p5 sketch
@@ -330,24 +326,25 @@
       result.data = this.resultJSON = e; // full JSON of callback event
       result.success = this.resultValue = e.returnValue; // was successful?
       // store latest result in top-level object struct
-      result.text = this.resultString = e.results[e.results.length-1][0].transcript.trim();
-      result.confidence = this.resultConfidence = e.results[e.results.length-1][0].confidence;
-      if(that.onResult!=undefined) that.onResult(result);
+      var _result = e.results[e.results.length - 1][0];
+      result.text = this.resultString = _result.transcript.trim();
+      result.confidence = this.resultConfidence = _result.confidence;
+      if(that.onResult !== undefined) that.onResult(result);
     };
 
     // fires when the recognition system starts (i.e. when you 'allow'
     // the mic to be used in the browser).
     this.rec.onstart = function(e) {
-      if(that.onStart!=undefined) that.onStart(e);
+      if(that.onStart !== undefined) that.onStart(e);
     };
     // fires on a client-side error (server-side errors are expressed
     // by the resultValue in the JSON coming back as 'false').
     this.rec.onerror = function(e) {
-      if(that.onError!=undefined) that.onError(e);
+      if(that.onError !== undefined) that.onError(e);
     };
     // fires when the recognition finishes, in non-continuous mode.
     this.rec.onend = function() {
-      if(that.onEnd!=undefined) that.onEnd();
+      if(that.onEnd !== undefined) that.onEnd();
     };
 
   }; // end p5.SpeechRec constructor
@@ -358,12 +355,31 @@
   // this one 'start' cycle.  if you need to recognize speech more
   // than once, use continuous mode rather than firing start()
   // multiple times in a single script.
-  p5.SpeechRec.prototype.start = function() {
+  p5.SpeechRec.prototype.start = function(_continuous, _interimResults) {
     if('webkitSpeechRecognition' in window) {
-      this.rec.continuous = this.continuous;
-      this.rec.interimResults = this.interimResults;
+      this.rec.continuous = this.continuous = _continuous === undefined ? this.continuous : _continuous;
+      this.rec.interimResults = this.interimResults = _interimResults === undefined ? this.interimResults : _interimResults;
       this.rec.start();
     }
+  };
+
+  // stop the speech recognition engine.
+  p5.SpeechRec.prototype.stop = function() {
+    if('webkitSpeechRecognition' in window) {
+      this.rec.stop();
+    }
+  };
+
+  // cancel the speech recognition engine.
+  p5.SpeechRec.prototype.cancel = function() {
+    if('webkitSpeechRecognition' in window) {
+      this.rec.abprt();
+    }
+  };
+
+  // sets the language of the recognition.
+  p5.SpeechRec.prototype.setLang = function(_lang) {
+    this.rec.lang = _lang;
   };
 
 }));

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -103,19 +103,19 @@
         //
 
         that.utterance.onstart = function(e) {
-          //console.log("STARTED");
+          //console.log('STARTED');
           if(that.onStart !== undefined) that.onStart(e);
         };
         that.utterance.onpause = function(e) {
-          //console.log("PAUSED");
+          //console.log('PAUSED');
           if(that.onPause !== undefined) that.onPause(e);
         };
         that.utterance.onresume = function(e) {
-          //console.log("RESUMED");
+          //console.log('RESUMED');
           if(that.onResume !== undefined) that.onResume(e);
         };
         that.utterance.onend = function(e) {
-          //console.log("ENDED");
+          //console.log('ENDED');
           if(that.onEnd !== undefined) that.onEnd(e);
         };
 
@@ -154,7 +154,7 @@
       }
     }
     else {
-    	console.log("p5.Speech: voices not loaded yet!")
+    	console.log('p5.Speech: voices not loaded yet!')
     }
   };
 
@@ -249,7 +249,7 @@
     }
     else {
       this.rec = null;
-      console.log("p5.SpeechRec: webkitSpeechRecognition not supported in this browser.");
+      console.log('p5.SpeechRec: webkitSpeechRecognition is not supported in this browser.');
     }
 
     // This callback is somewhat required so add in here
@@ -373,7 +373,7 @@
   // cancel the speech recognition engine.
   p5.SpeechRec.prototype.cancel = function() {
     if('webkitSpeechRecognition' in window) {
-      this.rec.abprt();
+      this.rec.abort();
     }
   };
 

--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -29,6 +29,11 @@
 //                         p5.Speech
 // =============================================================================
 
+  var _SpeechRecognition = window.SpeechRecognition ||
+                           window.webkitSpeechRecognition ||
+                           window.mozSpeechRecognition ||
+                           window.msSpeechRecognition;
+  var _srAvailable = _SpeechRecognition !== undefined;
 
   /**
    * Base class for a Speech Synthesizer
@@ -73,10 +78,10 @@
     // checkig parameters of constructor is an initial voice selector
     this.initvoice;
 
-    if(_callback !== undefined) {
+    if(_callback) {
       this.onLoad = _callback;
     }
-    if(_dv !== undefined) {
+    if(_dv) {
       this.initvoice = _dv;
     }
 
@@ -89,41 +94,41 @@
     // we use this function to load the voice array and bind our
     // custom callback functions.
     window.speechSynthesis.onvoiceschanged = function() {
-      if(that.isLoaded == false) { // run only once
-        that.voices = window.speechSynthesis.getVoices();
-        that.isLoaded = true; // we're ready
-
-        if(that.initvoice !== undefined) {
-          that.setVoice(that.initvoice); // set a custom initial voice
-        }
-
-
-        //
-        // bind other custom callbacks:
-        //
-
-        that.utterance.onstart = function(e) {
-          //console.log('STARTED');
-          if(that.onStart !== undefined) that.onStart(e);
-        };
-        that.utterance.onpause = function(e) {
-          //console.log('PAUSED');
-          if(that.onPause !== undefined) that.onPause(e);
-        };
-        that.utterance.onresume = function(e) {
-          //console.log('RESUMED');
-          if(that.onResume !== undefined) that.onResume(e);
-        };
-        that.utterance.onend = function(e) {
-          //console.log('ENDED');
-          if(that.onEnd !== undefined) that.onEnd(e);
-        };
-
-        // fire custom onLoad() callback, if it exists:
-        if(that.onLoad !== undefined) {
-          that.onLoad();
-        }
+      if(that.isLoaded) { // run only once
+        return;
       }
+      
+      that.voices = window.speechSynthesis.getVoices();
+      that.isLoaded = true; // we're ready
+
+      if(that.initvoice) {
+        that.setVoice(that.initvoice); // set a custom initial voice
+      }
+
+
+      //
+      // bind other custom callbacks:
+      //
+
+      that.utterance.onstart = function(e) {
+        //console.log('STARTED');
+        if(that.onStart) that.onStart(e);
+      };
+      that.utterance.onpause = function(e) {
+        //console.log('PAUSED');
+        if(that.onPause) that.onPause(e);
+      };
+      that.utterance.onresume = function(e) {
+        //console.log('RESUMED');
+        if(that.onResume) that.onResume(e);
+      };
+      that.utterance.onend = function(e) {
+        //console.log('ENDED');
+        if(that.onEnd) that.onEnd(e);
+      };
+      
+      // fire custom onLoad() callback, if it exists:
+      if(that.onLoad) that.onLoad();
     };
 
   };     // end p5.Speech constructor
@@ -132,29 +137,30 @@
   // Setting callbacks with functions instead
   p5.Speech.prototype.started = function(callback) {
     this.onStart = callback;
-  }
+  };
 
   p5.Speech.prototype.ended = function(callback) {
     this.onEnd = callback;
-  }
+  };
 
   p5.Speech.prototype.paused = function(callback) {
     this.onPause = callback;
-  }
+  };
 
   p5.Speech.prototype.resumed = function(callback) {
     this.onResume = callback;
-  }
+  };
 
   // logVoices() - dump voice names to javascript console:
   p5.Speech.prototype.logVoices = function() {
     if(this.isLoaded) {
-      for(var i = 0; i < this.voices.length; i++) {
-        console.log(this.voices[i].name);
-      }
+      var voiceList = this.voices.map(function(n) {
+          return 'Name: "' + n.name + '" | Language code: ' + n.lang;
+        }).join('\n');
+      console.log(voiceList);
     }
     else {
-    	console.log('p5.Speech: voices not loaded yet!')
+    	console.log('p5.Speech: voices not loaded yet!');
     }
   };
 
@@ -162,8 +168,15 @@
   // (using voices found in the voices[] array), or by index.
   p5.Speech.prototype.setVoice = function(_v) {
     // type check so you can set by label or by index:
-    if(typeof _v === 'string') this.utterance.voice = this.voices.find(function(v) { return v.name === _v; });
-    else if(typeof _v === 'number') this.utterance.voice = this.voices[Math.min(Math.max(_v,0), this.voices.length-1)];
+    if(typeof _v === 'string') {
+      this.utterance.voice = this.voices.find(function(v) {
+          return v.name === _v;
+        });
+    }
+    else if(typeof _v === 'number') {
+      var index = Math.min(Math.max(_v, 0), this.voices.length - 1);
+      this.utterance.voice = this.voices[index];
+    }
   };
 
   // volume of voice. API range 0.0-1.0.
@@ -244,12 +257,12 @@
     //
 
     // make a recognizer object.
-    if('webkitSpeechRecognition' in window) {
-      this.rec = new webkitSpeechRecognition();
+    if(_srAvailable) {
+      this.rec = new _SpeechRecognition();
     }
     else {
       this.rec = null;
-      console.log('p5.SpeechRec: webkitSpeechRecognition is not supported in this browser.');
+      console.log('p5.SpeechRec: SpeechRecognition is not supported in this browser.');
     }
 
     // This callback is somewhat required so add in here
@@ -260,7 +273,7 @@
     // no list of valid models in API, but it must use BCP-47.
     // here's some hints:
     // http://stackoverflow.com/questions/14257598/what-are-language-codes-for-voice-recognition-languages-in-chromes-implementati
-    if(_lang !== undefined) this.setLang(_lang);
+    if(_lang) this.setLang(_lang);
 
 
     // callback properties to be filled in within the p5 sketch
@@ -329,25 +342,30 @@
       var _result = e.results[e.results.length - 1][0];
       result.text = this.resultString = _result.transcript.trim();
       result.confidence = this.resultConfidence = _result.confidence;
-      if(that.onResult !== undefined) that.onResult(result);
+      if(that.onResult) that.onResult(result);
     };
 
     // fires when the recognition system starts (i.e. when you 'allow'
     // the mic to be used in the browser).
     this.rec.onstart = function(e) {
-      if(that.onStart !== undefined) that.onStart(e);
+      if(that.onStart) that.onStart(e);
     };
     // fires on a client-side error (server-side errors are expressed
     // by the resultValue in the JSON coming back as 'false').
     this.rec.onerror = function(e) {
-      if(that.onError !== undefined) that.onError(e);
+      if(that.onError) that.onError(e);
     };
     // fires when the recognition finishes, in non-continuous mode.
-    this.rec.onend = function() {
-      if(that.onEnd !== undefined) that.onEnd();
+    this.rec.onend = function(e) {
+      if(that.onEnd) that.onEnd(e);
     };
 
   }; // end p5.SpeechRec constructor
+
+  // private, check if speech recognition is available.
+  p5.SpeechRec.prototype._hasRec = function() {
+    return _srAvailable && this.rec && this.rec instanceof _SpeechRecognition;
+  };
 
   // start the speech recognition engine.  this will prompt a
   // security dialog in the browser asking for permission to
@@ -356,7 +374,7 @@
   // than once, use continuous mode rather than firing start()
   // multiple times in a single script.
   p5.SpeechRec.prototype.start = function(_continuous, _interimResults) {
-    if('webkitSpeechRecognition' in window) {
+    if(this._hasRec()) {
       this.rec.continuous = this.continuous = _continuous === true;
       this.rec.interimResults = this.interimResults = _interimResults === true;
       this.rec.start();
@@ -365,21 +383,23 @@
 
   // stop the speech recognition engine.
   p5.SpeechRec.prototype.stop = function() {
-    if('webkitSpeechRecognition' in window) {
+    if(this._hasRec()) {
       this.rec.stop();
     }
   };
 
   // cancel the speech recognition engine.
   p5.SpeechRec.prototype.cancel = function() {
-    if('webkitSpeechRecognition' in window) {
+    if(this._hasRec()) {
       this.rec.abort();
     }
   };
 
   // sets the language of the recognition.
   p5.SpeechRec.prototype.setLang = function(_lang) {
-    this.rec.lang = _lang;
+    if(this._hasRec()) {
+      this.rec.lang = _lang;
+    }
   };
 
 }));


### PR DESCRIPTION
- Use `false`/`true` instead of `0`/`1`.
- Removed a superfluous console.log,
- Use `Array.prototype.find` instead of `Array.prototype.filter`
- Set `this.res` to null when `webkitSpeechRecognition` is not available.