### PR TITLE
Add the stop function to p5 speech recognition

### DIFF
--- a/lib/p5.speech.js
+++ b/lib/p5.speech.js
@@ -354,6 +354,13 @@
     }
   };
 
+  // Add function to stop the speech recognition from keep listening
+  p5.SpeechRec.prototype.stop = function()  {
+    if('webkitSpeechRecognition' in window) {
+      this.rec.stop();
+    }
+  };
+
 }));
 
 /*


### PR DESCRIPTION
I add the stop function to p5 speech recognition library in the file lib/p5.speech.js from line 357-363.

This prevents the browser from listening unnecessary speech from user.